### PR TITLE
Update max pagination page to limit requests

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,1 +1,1 @@
-AMAZON_BASE_URL = 'https://www.amazon.co.jp'
+AMAZON_BASE_URL = 'https://www.amazon.co.uk'

--- a/core_extract_comments.py
+++ b/core_extract_comments.py
@@ -10,10 +10,7 @@ from core_utils import get_soup, extract_product_id, persist_comment_to_disk
 
 def get_product_reviews_url(item_id, page_number=None):
     if not page_number:
-        return AMAZON_BASE_URL + '/product-reviews/{}/ref=' \
-                                 'cm_cr_arp_d_paging_btm_1?ie=UTF8&reviewerType=all_reviews' \
-                                 '&showViewpoints=1&sortBy=helpful'.format(
-            item_id)
+        page_number = 1
     return AMAZON_BASE_URL + '/product-reviews/{}/ref=' \
                              'cm_cr_arp_d_paging_btm_1?ie=UTF8&reviewerType=all_reviews' \
                              '&showViewpoints=1&sortBy=helpful&pageNumber={}'.format(
@@ -52,8 +49,9 @@ def get_comments_with_product_id(product_id):
     max_page_number = int(max_page_number[-1].text) if max_page_number else 1
 
     for page_number in range(1, max_page_number + 1):
-        product_reviews_link = get_product_reviews_url(product_id, page_number)
-        so = get_soup(product_reviews_link)
+        if page_number > 1:
+            product_reviews_link = get_product_reviews_url(product_id, page_number)
+            so = get_soup(product_reviews_link)
 
         cr_review_list_so = so.find(id='cm_cr-review_list')
 
@@ -71,6 +69,9 @@ def get_comments_with_product_id(product_id):
             rating = review.find(attrs={'data-hook': 'review-star-rating'}).attrs['class'][2].split('-')[-1]
             body = review.find(attrs={'data-hook': 'review-body'}).text
             title = review.find(attrs={'data-hook': 'review-title'}).text
+            author_url = review.find(attrs={'data-hook': 'genome-widget'}).find('a', href=True)
+            if author_url:
+                author_url = author_url['href']
             try:
                 helpful = review.find(attrs={'data-hook': 'helpful-vote-statement'}).text
                 helpful = helpful.strip().split(' ')[0]
@@ -83,9 +84,16 @@ def get_comments_with_product_id(product_id):
             logging.info('RATING   = ' + rating)
             logging.info('CONTENT  = ' + body)
             logging.info('HELPFUL  = ' + helpful)
+            logging.info('AUTHOR URL  = ' + author_url if author_url else '')
             logging.info('***********************************************\n')
             reviews.append({'title': title,
                             'rating': rating,
                             'body': body,
-                            'product_id': product_id})
+                            'product_id': product_id,
+                            'author_url': author_url})
     return reviews
+
+
+if __name__ == '__main__':
+    reviews = get_comments_with_product_id('B00BV0W8RQ')
+    persist_comment_to_disk(reviews)

--- a/core_extract_comments.py
+++ b/core_extract_comments.py
@@ -8,7 +8,12 @@ from core_utils import get_soup, extract_product_id, persist_comment_to_disk
 
 # https://www.amazon.co.jp/product-reviews/B00Z16VF3E/ref=cm_cr_arp_d_paging_btm_1?ie=UTF8&reviewerType=all_reviews&showViewpoints=1&sortBy=helpful&pageNumber=1
 
-def get_product_reviews_url(item_id, page_number):
+def get_product_reviews_url(item_id, page_number=None):
+    if not page_number:
+        return AMAZON_BASE_URL + '/product-reviews/{}/ref=' \
+                                 'cm_cr_arp_d_paging_btm_1?ie=UTF8&reviewerType=all_reviews' \
+                                 '&showViewpoints=1&sortBy=helpful'.format(
+            item_id)
     return AMAZON_BASE_URL + '/product-reviews/{}/ref=' \
                              'cm_cr_arp_d_paging_btm_1?ie=UTF8&reviewerType=all_reviews' \
                              '&showViewpoints=1&sortBy=helpful&pageNumber={}'.format(
@@ -40,7 +45,13 @@ def get_comments_with_product_id(product_id):
         return reviews
     if not re.match('^[A-Z0-9]{10}$', product_id):
         return reviews
-    for page_number in range(100):
+
+    product_reviews_link = get_product_reviews_url(product_id)
+    so = get_soup(product_reviews_link)
+    max_page_number = so.find_all("li", {'class': 'page-button'})
+    max_page_number = int(max_page_number[-1].text) if max_page_number else 1
+
+    for page_number in range(1, max_page_number + 1):
         product_reviews_link = get_product_reviews_url(product_id, page_number)
         so = get_soup(product_reviews_link)
 


### PR DESCRIPTION
Noticed that there is a maximum of 100 pages, but this can be troublesome if a product has more than 1000 reviews.
Overloaded get_product_reviews_url() to handle requests without page number